### PR TITLE
Rescue another NPE that may stop the whole loop

### DIFF
--- a/lib/ghq_transfer.rb
+++ b/lib/ghq_transfer.rb
@@ -26,13 +26,13 @@ module GhqTransfer
 
         origin_url.chomp!
 
-        host, user, repo = if /^git@.+/ === origin_url
-                             extract_paths_from_ssh(origin_url)
-                           else
-                             extract_paths_from_https(origin_url)
-                           end
-
         begin
+          host, user, repo = if /^git@.+/ === origin_url
+                               extract_paths_from_ssh(origin_url)
+                             else
+                               extract_paths_from_https(origin_url)
+                             end
+
           dest_dir = ghq_root.join(host, user)
           dest_path = dest_dir.join(repo)
 


### PR DESCRIPTION
`extract_paths_from_https` causes an unrescued NPE when the URI does not include enough number of `/`s .
This patch rescues the error and just skips processing that repo in such case.